### PR TITLE
Update

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -36,3 +36,24 @@ export function pngDownloadUrl(runId) {
 export function excalidrawDownloadUrl(runId) {
   return `${BASE}/api/download/excalidraw/${runId}`;
 }
+
+export async function fetchPngBlobUrl(runId) {
+  const res = await fetch(pngDownloadUrl(runId));
+  if (!res.ok) throw new Error("Failed to fetch PNG");
+  const blob = await res.blob();
+  return URL.createObjectURL(blob);
+}
+
+export async function downloadFile(url, filename) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error("Download failed");
+  const blob = await res.blob();
+  const blobUrl = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = blobUrl;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(blobUrl);
+}

--- a/frontend/src/components/DiagramViewer.jsx
+++ b/frontend/src/components/DiagramViewer.jsx
@@ -1,9 +1,15 @@
 import React, { useEffect, useState, useRef } from "react";
-import { pngDownloadUrl, excalidrawDownloadUrl } from "../api";
+import {
+  pngDownloadUrl,
+  excalidrawDownloadUrl,
+  fetchPngBlobUrl,
+  downloadFile,
+} from "../api";
 
 function DiagramViewer({ excalidrawFile, runId }) {
   const [Excalidraw, setExcalidraw] = useState(null);
   const [loadError, setLoadError] = useState(false);
+  const [pngBlobUrl, setPngBlobUrl] = useState(null);
   const containerRef = useRef(null);
 
   // Dynamically import @excalidraw/excalidraw
@@ -22,6 +28,22 @@ function DiagramViewer({ excalidrawFile, runId }) {
       cancelled = true;
     };
   }, []);
+
+  // Fetch PNG as blob URL for reliable preview (works regardless of
+  // Content-Disposition headers or proxy configuration)
+  useEffect(() => {
+    if (!runId) return;
+    let cancelled = false;
+    fetchPngBlobUrl(runId)
+      .then((url) => {
+        if (!cancelled) setPngBlobUrl(url);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+      if (pngBlobUrl) URL.revokeObjectURL(pngBlobUrl);
+    };
+  }, [runId]);
 
   if (!excalidrawFile) {
     return (
@@ -42,33 +64,37 @@ function DiagramViewer({ excalidrawFile, runId }) {
     scrollToContent: true,
   };
 
+  const pngPreview = pngBlobUrl ? (
+    <img
+      src={pngBlobUrl}
+      alt="Architecture Diagram"
+      style={{
+        width: "100%",
+        height: "100%",
+        objectFit: "contain",
+        padding: 16,
+      }}
+    />
+  ) : (
+    <div className="loading">
+      <div className="spinner" />
+      Loading diagram preview...
+    </div>
+  );
+
+  const handleDownloadPng = () => {
+    downloadFile(pngDownloadUrl(runId), "architecture.png");
+  };
+
+  const handleDownloadExcalidraw = () => {
+    downloadFile(excalidrawDownloadUrl(runId), "architecture.excalidraw");
+  };
+
   return (
     <div>
       <div className="diagram-container" ref={containerRef}>
         {loadError ? (
-          // Fallback: show PNG image if Excalidraw component fails to load
-          runId ? (
-            <img
-              src={pngDownloadUrl(runId)}
-              alt="Architecture Diagram"
-              style={{
-                width: "100%",
-                height: "100%",
-                objectFit: "contain",
-                padding: 16,
-              }}
-            />
-          ) : (
-            <div
-              style={{
-                padding: 24,
-                textAlign: "center",
-                color: "#868e96",
-              }}
-            >
-              Could not load interactive diagram viewer.
-            </div>
-          )
+          pngPreview
         ) : Excalidraw ? (
           <Excalidraw
             initialData={initialData}
@@ -78,29 +104,21 @@ function DiagramViewer({ excalidrawFile, runId }) {
             theme="light"
           />
         ) : (
-          <div className="loading">
-            <div className="spinner" />
-            Loading diagram viewer...
-          </div>
+          pngPreview
         )}
       </div>
 
       {runId && (
         <div className="diagram-actions">
-          <a
-            className="btn btn-secondary"
-            href={pngDownloadUrl(runId)}
-            download="architecture.png"
-          >
+          <button className="btn btn-secondary" onClick={handleDownloadPng}>
             Download PNG
-          </a>
-          <a
+          </button>
+          <button
             className="btn btn-secondary"
-            href={excalidrawDownloadUrl(runId)}
-            download="architecture.excalidraw"
+            onClick={handleDownloadExcalidraw}
           >
             Download Excalidraw
-          </a>
+          </button>
         </div>
       )}
     </div>


### PR DESCRIPTION
Fix: Diagram Preview & Download Buttons

Problem
The three diagram features in the web app were broken:
1. **Preview** — The PNG image didn't render inline; browsers treated the API response as a download instead of displaying it, due to `Content-Disposition` / proxy header issues.
2. **Download PNG** — The `<a href download>` link didn't reliably trigger a `.png` save (especially through the Vite dev proxy).
3. **Download Excalidraw** — Same issue — the `.excalidraw` file wasn't saved in the correct format.

Root Cause
Using raw `<a href="..." download="...">` links for cross-origin or proxied API endpoints is unreliable. Browsers may ignore the `download` attribute when the response comes from a different origin or has conflicting headers. Similarly, pointing an `<img src>` at an endpoint that returns `Content-Disposition: attachment` can prevent the image from rendering.

Fix
**api.js** — Added two helpers:
- `fetchPngBlobUrl(runId)` — Fetches the PNG via `fetch()`, converts to a Blob object URL for use in `<img>` tags.
- `downloadFile(url, filename)` — Fetches any file as a Blob, creates a temporary `<a>` element with the blob URL, programmatically clicks it, then cleans up. This guarantees the browser saves the file with the correct name and format.

**DiagramViewer.jsx**:
- **Preview**: Added a `useEffect` that fetches the PNG as a blob URL. This is used as immediate preview while Excalidraw loads, and as the fallback if Excalidraw fails to load.
- **Download buttons**: Changed from `<a>` links to `<button onClick>` handlers that call `downloadFile()`, ensuring reliable save behavior for both `.png` and `.excalidraw` formats.

Testing Completed
- [x ] Preview loads and displays the architecture diagram image
- [x] "Download PNG" saves a valid `architecture.png` file
- [x] "Download Excalidraw" saves a valid `architecture.excalidraw` file
- [x] Excalidraw interactive viewer still loads when the library is available
- [x] Works in both dev (Vite proxy) and production (static build served by FastAPI)