### PR TITLE
chore: add GitHub issue/PR templates and issue auto-assign workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug Report
+about: Report a reproducible bug or unexpected behaviour
+title: "[Bug]: "
+labels: ["bug"]
+assignees: ShivamGoyal03
+---
+
+## Description
+
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+
+1. 
+2. 
+3. 
+
+## Expected Behaviour
+
+What you expected to happen.
+
+## Actual Behaviour
+
+What actually happened. Include the full error message or traceback if applicable.
+
+```
+paste error here
+```
+
+## Environment
+
+- OS: <!-- e.g. Windows 11, Ubuntu 22.04 -->
+- Python version: <!-- e.g. 3.11.9 -->
+- Branch / commit: <!-- e.g. main @ abc1234 -->
+- Deployment: <!-- local / web app / hosted agent -->
+
+## Additional Context
+
+Any other context, screenshots, or logs that might help.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: Documentation
+    url: https://github.com/Azure-Samples/agent-architecture-review-sample/blob/main/docs/deployment.md
+    about: Read the deployment and setup guide before opening an issue.
+  - name: Contributing Guide
+    url: https://github.com/Azure-Samples/agent-architecture-review-sample/blob/main/CONTRIBUTING.md
+    about: Want to contribute? Start here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+title: "[Feature]: "
+labels: ["enhancement"]
+assignees: ShivamGoyal03
+---
+
+## Summary
+
+A clear and concise description of the feature you'd like to see.
+
+## Problem it Solves
+
+What problem or limitation does this address? Who benefits?
+
+## Proposed Solution
+
+Describe the solution you have in mind. Be as specific as possible.
+
+## Alternatives Considered
+
+Any alternative approaches you've thought about and why you prefer this one.
+
+## Additional Context
+
+Mockups, examples, or links to related issues / discussions.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+## Description
+
+A clear and concise summary of the changes in this PR.
+
+Closes # <!-- issue number, e.g. Closes #19 -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / code improvement
+- [ ] Documentation update
+- [ ] CI / tooling change
+
+## Changes Made
+
+- 
+- 
+
+## Testing
+
+Describe how you tested your changes.
+
+- [ ] Ran `pytest tests/` - all tests pass
+- [ ] Tested locally with `python run_local.py`
+- [ ] Tested the web app (`scripts/windows/dev.ps1` or `scripts/linux-mac/dev.sh`)
+- [ ] Added / updated tests where applicable
+
+## Checklist
+
+- [ ] My changes follow the coding conventions in `AGENTS.md`
+- [ ] I have not duplicated logic between `main.py`, `api.py`, and `tools.py`
+- [ ] No secrets or credentials have been committed
+- [ ] Documentation updated if behaviour changed
+- [ ] PR title is descriptive and references the issue (e.g. `fix: resolve ImportError #19`)

--- a/.github/workflows/issue-management.yml
+++ b/.github/workflows/issue-management.yml
@@ -1,0 +1,34 @@
+name: Issue Management
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  welcome-and-assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign issue to maintainer
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: ['ShivamGoyal03'],
+            });
+
+      - name: Post welcome comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `👋 Thanks for raising this issue! We appreciate you taking the time - please bear with us while we look into it.\n\n**@ShivamGoyal03** will review and respond to you as soon as possible.\n\nIn the meantime, if you have a fix in mind or feel confident about the solution, feel free to raise a PR - contributions are always welcome! Please check the [contributing guide](../blob/main/CONTRIBUTING.md) before opening one.`,
+            });

--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,6 @@ build/
 # Virtual environments
 .venv*/
 venv/
-.github
-
 # Environment files (secrets)
 .env
 .env.local


### PR DESCRIPTION
- Add bug report and feature request issue templates with @ShivamGoyal03 set as default assignee
- Add ISSUE_TEMPLATE/config.yml disabling blank issues and linking docs
- Add PR template with description, type of change, and contributor checklist
- Add issue-management GitHub Actions workflow: auto-assigns every new issue to ShivamGoyal03 and posts a welcome comment tagging them
- Remove .github from .gitignore (was incorrectly excluded)